### PR TITLE
stop using alpha mode for ETC2

### DIFF
--- a/src/AEPi/codecs/Tex2ImgCodec.py
+++ b/src/AEPi/codecs/Tex2ImgCodec.py
@@ -16,7 +16,7 @@ TEX2IMG_FORMAT_MAP = {
     CompressionFormat.DXT1: 5,
     CompressionFormat.DXT5: 6,
     CompressionFormat.ETC1: 0,
-    CompressionFormat.ETC2: 3
+    CompressionFormat.ETC2: 2
 }
 
 

--- a/src/AEPi/constants.py
+++ b/src/AEPi/constants.py
@@ -102,7 +102,6 @@ FORMAT_BITCOUNTS[CompressionFormat.ETC1] = 4
 FORMAT_BITCOUNTS[CompressionFormat.ETC2] = 8 # ?
 
 BGR_FORMATS.add(CompressionFormat.ETC1)
-BGR_FORMATS.add(CompressionFormat.ETC2)
 
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC12A)
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC14A)

--- a/src/AEPi/constants.py
+++ b/src/AEPi/constants.py
@@ -5,7 +5,7 @@ from . import exceptions
 
 FORMAT_PILLOW_MODES: Dict["CompressionFormat", str] = {}
 FORMAT_BITCOUNTS: Dict["CompressionFormat", int] = {}
-BGRA_FORMATS: Set["CompressionFormat"] = set()
+BGR_FORMATS: Set["CompressionFormat"] = set()
 MIPMAPPABLE_FORMATS: Set["CompressionFormat"] = set()
 MASK_MIPMAPPED_FLAG = 0b00000010
 MASK_FORMAT_ID = 0b11111101
@@ -72,7 +72,7 @@ class CompressionFormat(Enum):
     
     @property
     def isBgra(self):
-        return self in BGRA_FORMATS
+        return self in BGR_FORMATS
 
 
 FORMAT_PILLOW_MODES[CompressionFormat.Uncompressed] = "RGBA" # ?
@@ -86,7 +86,7 @@ FORMAT_PILLOW_MODES[CompressionFormat.DXT1] = "RGB"
 FORMAT_PILLOW_MODES[CompressionFormat.DXT3] = "RGBA"
 FORMAT_PILLOW_MODES[CompressionFormat.DXT5] = "RGBA"
 FORMAT_PILLOW_MODES[CompressionFormat.ETC1] = "RGB"
-FORMAT_PILLOW_MODES[CompressionFormat.ETC2] = "RGBA"
+FORMAT_PILLOW_MODES[CompressionFormat.ETC2] = "RGB"
 
 FORMAT_BITCOUNTS[CompressionFormat.Uncompressed] = 8 # ?
 FORMAT_BITCOUNTS[CompressionFormat.Uncompressed_UI] = 8 # ?
@@ -101,8 +101,8 @@ FORMAT_BITCOUNTS[CompressionFormat.DXT5] = 8
 FORMAT_BITCOUNTS[CompressionFormat.ETC1] = 4
 FORMAT_BITCOUNTS[CompressionFormat.ETC2] = 8 # ?
 
-BGRA_FORMATS.add(CompressionFormat.ETC1)
-BGRA_FORMATS.add(CompressionFormat.ETC2)
+BGR_FORMATS.add(CompressionFormat.ETC1)
+BGR_FORMATS.add(CompressionFormat.ETC2)
 
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC12A)
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC14A)


### PR DESCRIPTION
**Notes for reviewer:**

* Fix reading format 23 as ETC2 BGRA when it's really BGR
