### PR TITLE
Enable writing ETC2

### DIFF
--- a/src/AEPi/codec.py
+++ b/src/AEPi/codec.py
@@ -8,7 +8,7 @@ from .exceptions import UnsupportedCompressionFormatException
 class ImageCodecAdaptor(ABC):
     @classmethod
     def compress(cls, im: Image, format: CompressionFormat, quality: Optional[CompressionQuality]) -> bytes:
-        """Compress a BGRA image into format `format`, with quality `quality`
+        """Compress an RGB(A) image into format `format`, with quality `quality`
 
         :param im: The image to compress
         :type im: Image
@@ -24,7 +24,7 @@ class ImageCodecAdaptor(ABC):
 
     @classmethod
     def decompress(cls, fp: bytes, format: CompressionFormat, width: int, height: int, quality: Optional[CompressionQuality]) -> Image:
-        """Decompress a `format`-compressed BGRA image into a BGRA Image.
+        """Decompress a `format`-compressed RGB(A) image into a RGB(A) Image.
 
         :param fp: The compressed image to decompress
         :type im: bytes
@@ -34,7 +34,7 @@ class ImageCodecAdaptor(ABC):
         :type width: int
         :param height: The height of the image
         :type height: int
-        :return: `fp`, decompressed into a BGRA image
+        :return: `fp`, decompressed into a RGB(A) image
         :rtype: Image
         """
         raise NotImplementedError(f"Codec {cls.__name__} is not capable of decompression")
@@ -51,7 +51,7 @@ def supportsFormats(
         both: Optional[Iterable[CompressionFormat]] = None
     ):
     """Class decorator marking an image codec as able to compress/decompress images into the given compression formats.
-    The codec class must assume that BGRA is passed, and return BGRA.
+    The codec class must assume that RGB(A) is passed, and return RGB(A).
 
     ```py
     supportsFormats(

--- a/src/AEPi/codecs/EtcPakCodec.py
+++ b/src/AEPi/codecs/EtcPakCodec.py
@@ -32,6 +32,7 @@ class EtcPakCodec(ImageCodecAdaptor):
             elif format is CompressionFormat.ETC2:
                 # etcpak does provide a function for etc2 compression, but it produces almost completely black images
                 # ETC2 is backwards compatible with ETC1, so as a stopgap we'll just compress as etc1
+                # https://www.khronos.org/assets/uplo...pengl-es-bof/Ericsson-ETC2-SIGGRAPH_Aug12.pdf
                 return etcpak.compress_to_etc1(imageIn.tobytes(), imageIn.width, imageIn.height) # type: ignore[reportUnknownVariableType]
             
         raise ValueError(f"Codec {EtcPakCodec.__name__} does not support format {format.name}")

--- a/src/AEPi/codecs/EtcPakCodec.py
+++ b/src/AEPi/codecs/EtcPakCodec.py
@@ -1,7 +1,8 @@
 from typing import Optional
-from typing import Optional
+
 from PIL.Image import Image
 from contextlib import nullcontext
+
 from ..codec import ImageCodecAdaptor, supportsFormats
 from ..constants import CompressionFormat, CompressionQuality
 from ..exceptions import DependancyMissingException
@@ -14,7 +15,8 @@ except ImportError as e:
 
 @supportsFormats(compresses=[
     CompressionFormat.DXT5,
-    CompressionFormat.ETC1
+    CompressionFormat.ETC1,
+    CompressionFormat.ETC2
 ])
 class EtcPakCodec(ImageCodecAdaptor):
     @classmethod
@@ -25,6 +27,11 @@ class EtcPakCodec(ImageCodecAdaptor):
                 return etcpak.compress_to_dxt5(imageIn.tobytes(), imageIn.width, imageIn.height) # type: ignore[reportUnknownVariableType]
 
             elif format is CompressionFormat.ETC1:
+                return etcpak.compress_to_etc1(imageIn.tobytes(), imageIn.width, imageIn.height) # type: ignore[reportUnknownVariableType]
+            
+            elif format is CompressionFormat.ETC2:
+                # etcpak does provide a function for etc2 compression, but it produces almost completely black images
+                # ETC2 is backwards compatible with ETC1, so as a stopgap we'll just compress as etc1
                 return etcpak.compress_to_etc1(imageIn.tobytes(), imageIn.width, imageIn.height) # type: ignore[reportUnknownVariableType]
             
         raise ValueError(f"Codec {EtcPakCodec.__name__} does not support format {format.name}")

--- a/src/AEPi/constants.py
+++ b/src/AEPi/constants.py
@@ -102,6 +102,7 @@ FORMAT_BITCOUNTS[CompressionFormat.ETC1] = 4
 FORMAT_BITCOUNTS[CompressionFormat.ETC2] = 8 # ?
 
 BGR_FORMATS.add(CompressionFormat.ETC1)
+BGR_FORMATS.add(CompressionFormat.ETC2)
 
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC12A)
 MIPMAPPABLE_FORMATS.add(CompressionFormat.PVRTC14A)


### PR DESCRIPTION
**Notes for reviewer:**

* there's no immediately obvious ETC2 codec to use, except for etcpak. etcpak's ETC2 compression function returns almost completely black images, it doesn't seem to be working properly.
  This PR is a stopgap solution - ETC2 is backwards compatible with ETC1, so for now we can just compress with ETC1.
  AEIs compressed in this way are opening as expected using tex2img.
