### PR TITLE
Symbols

### DIFF
--- a/src/AEPi/codecs/Tex2ImgCodec.py
+++ b/src/AEPi/codecs/Tex2ImgCodec.py
@@ -14,7 +14,7 @@ except ImportError as e:
 
 TEX2IMG_FORMAT_MAP = {
     # CompressionFormat.PVRTC14A: 12, # Tex2ImgCodec segfaults decoding PVRTC with all tests (#29)
-    CompressionFormat.ATC: 14,
+    CompressionFormat.ATC: 14, #cATC_RGBA_INTERPOLATED_ALPHA
     CompressionFormat.DXT1: 5,
     CompressionFormat.DXT5: 6,
     CompressionFormat.ETC1: 0,

--- a/src/AEPi/image/AEI.py
+++ b/src/AEPi/image/AEI.py
@@ -345,10 +345,11 @@ class AEI:
                     w = readUInt16(file, ENDIANNESS)
                     h = readUInt16(file, ENDIANNESS)
                     font[glyph] = Texture(x, y, w, h)
+
                 fonts.append(font)
         
             # for i, font in enumerate(fonts):
-            #     print({font 1.})
+            #     print(font {i}.)
             #     for key, value in font.items():
             #         print(f" {key} {value}")
         
@@ -405,7 +406,7 @@ class AEI:
         fp = io.BytesIO() if fp is None else fp
 
         # AEIs must contain at least one texture
-        if tempTexture := (len(self.textures) == 0):
+        if tempTexture := (len(self.textures) == 0 and len(self.fonts) == 0):
             self.addTexture(Texture(0, 0, self.width, self.height))
 
         try:
@@ -490,6 +491,7 @@ class AEI:
                 glyphs.write(uint16(g.width,  ENDIANNESS))
                 glyphs.write(uint16(g.height, ENDIANNESS))
             
+            fp.write(uint16(len(font), ENDIANNESS))
             fp.write(symbols.getvalue())
             fp.write(glyphs.getvalue())
 

--- a/src/AEPi/image/AEI.py
+++ b/src/AEPi/image/AEI.py
@@ -121,10 +121,14 @@ class AEI:
         elif y is None or width is None or height is None:
             raise ValueError("All of x, y, width and height are required")
         
-        if val1 < 0 or width < 1 or y < 0 or height < 1 or val1 + width > self.width or y + height > self.height:
+        x = val1
+        if x >= self.width or x + width <= 0 or y >= self.height or y + height <= 0:
+            raise ValueError("The bounding box has no common area with bounds of the AEI")
+        
+        if x < 0 or width < 1 or y < 0 or height < 1 or x + width > self.width or y + height > self.height:
             print("WARNING: The bounding box falls out of bounds of the AEI")
         
-        return (val1, y, width, height)
+        return (x, y, width, height)
 
 
     def _findTextureByBox(self, val1: Union[Texture, int], y: Optional[int] = None, width: Optional[int] = None, height: Optional[int] = None):

--- a/src/AEPi/image/AEI.py
+++ b/src/AEPi/image/AEI.py
@@ -312,13 +312,13 @@ class AEI:
             height = readUInt16(file, ENDIANNESS)
             numTextures = readUInt16(file, ENDIANNESS)
 
-            textures: List[Texture] = []
+            textures: list[Texture] = []
             for _ in range(numTextures):
-                texX = readUInt16(file, ENDIANNESS)
-                texY = readUInt16(file, ENDIANNESS)
-                texWidth = readUInt16(file, ENDIANNESS)
-                texHeight = readUInt16(file, ENDIANNESS)
-                textures.append(Texture(texX, texY, texWidth, texHeight))
+                x = readUInt16(file, ENDIANNESS)
+                y = readUInt16(file, ENDIANNESS)
+                w = readUInt16(file, ENDIANNESS)
+                h = readUInt16(file, ENDIANNESS)
+                textures.append(Texture(x, y, w, h))
 
             if format.isCompressed:
                 imageLength = readUInt32(file, ENDIANNESS)
@@ -327,10 +327,28 @@ class AEI:
 
             compressed = file.read(imageLength)
 
-            symbolGroups = readUInt16(file, ENDIANNESS)
+            fontsNum = readUInt16(file, ENDIANNESS)
+            fonts: list = []
 
-            if symbolGroups > 0:
-                raise UnsupportedAeiFeatureException("Symbol maps")
+            for _ in range(fontsNum):
+                fontLen = readUInt16(file, ENDIANNESS)
+                font: dict[str,Texture] = {}
+                symbols: list[str] = []
+                for _ in range(fontLen):
+                    glyph = file.read(2).decode("utf-16le")
+                    symbols.append(glyph)
+
+                for glyph in symbols:
+                    x = readUInt16(file, ENDIANNESS)
+                    y = readUInt16(file, ENDIANNESS)
+                    w = readUInt16(file, ENDIANNESS)
+                    h = readUInt16(file, ENDIANNESS)
+                    font[glyph] = Texture(x, y, w, h)
+                fonts.append(font)
+        
+            # for sg in fonts:
+            #     for glyph in sg:
+            #         print(glyph.char)
             
             bQuality = readUInt8(file, ENDIANNESS, None)
             quality = cast(Optional[CompressionQuality], bQuality) 

--- a/src/AEPi/image/texture.py
+++ b/src/AEPi/image/texture.py
@@ -50,3 +50,12 @@ class Texture:
 
     def __str__(self):
         return f"Texture: x: {self.x}, y: {self.y}, w: {self.width}, h: {self.height}"
+    
+    def equals(self, other: "Texture") -> bool: 
+        if not isinstance(other, Texture):
+            return False
+        return  (
+            self.x == other.x and
+            self.y == other.y and
+            self.width == other.width and
+            self.height == other.height)

--- a/src/AEPi/image/texture.py
+++ b/src/AEPi/image/texture.py
@@ -47,3 +47,6 @@ class Texture:
         :type value: Tuple[int, int]
         """
         (self.x, self.y) = value
+
+    def __str__(self):
+        return f"Texture: x: {self.x}, y: {self.y}, w: {self.width}, h: {self.height}"

--- a/src/tests/image/test_AEI.py
+++ b/src/tests/image/test_AEI.py
@@ -184,6 +184,44 @@ def test_write_twoTextures_isCorrect():
             assert expectedText == actualText
     g_useSmiley = False
 
+def test_write_symbols_isCorrect():
+    global g_useSmiley
+    g_useSmiley = True
+
+    _test_tex = [
+        # font 0
+        Texture(0,0,3,3),
+        Texture(0,0,3,3),
+        # font 1
+        Texture(0,4,4,4),
+        Texture(4,4,4,4),
+        Texture(8,4,4,4)
+    ]
+    with smileyImage() as png:
+        with AEI(png) as aei, BytesIO() as temp:
+            aei.fonts = []
+            aei.fonts.append({
+                ".": _test_tex[0],
+                "a": _test_tex[1],
+            })
+            aei.fonts.append({
+                "ж": _test_tex[2],
+                "ą": _test_tex[3],
+                "™": _test_tex[4]
+            })
+            aei.write(temp, format=CompressionFormat.Uncompressed_UI, quality=3)
+            with AEI.read(temp) as new_aei:
+                assert len(new_aei.fonts) == 2
+                assert len(new_aei.fonts[0]) == 2
+                assert len(new_aei.fonts[1]) == 3
+                assert new_aei.fonts[0]["."] == _test_tex[0]
+                assert new_aei.fonts[0]["a"] == _test_tex[1]
+                assert new_aei.fonts[1]["ж"] == _test_tex[2]
+                assert new_aei.fonts[1]["ą"] == _test_tex[3]
+                assert new_aei.fonts[1]["™"] == _test_tex[4]
+           
+    g_useSmiley = False
+
 #endregion write
 #endregion aei files
 #region textures
@@ -205,18 +243,15 @@ def test_addTexture_withImage_addsImage():
                 assert aei._image.getpixel((x, y)) == png.getpixel((x, y)) # type: ignore[reportUnknownMemberType]
 
 
-def test_addTexture_conflict_raises():
+def test_addTexture_conflict_warns():
     with AEI((10, 10)) as aei:
         aei.addTexture(Texture(0, 0, 10, 10))
-
-        with pytest.raises(ValueError):
-            aei.addTexture(Texture(0, 0, 10, 10))
+        aei.addTexture(Texture(0, 0, 10, 10))
 
 
-def test_addTexture_outOfBounds_raises():
+def test_addTexture_outOfBounds_warns():
     with AEI((10, 10)) as aei:
-        with pytest.raises(ValueError):
-            aei.addTexture(Texture(11, 0, 10, 10))
+        aei.addTexture(Texture(11, 0, 10, 10))
 
 
 def test_addTexture_withImage_incorrectMode_raises():
@@ -246,10 +281,9 @@ def test_removeTexture_unknown_raises():
             aei.removeTexture(0, 0, 10, 10)
 
 
-def test_removeTexture_outOfBounds_raises():
+def test_removeTexture_outOfBounds_warns():
     with AEI((10, 10)) as aei:
-        with pytest.raises(ValueError):
-            aei.removeTexture(11, 0, 10, 10)
+        aei.removeTexture(11, 0, 10, 10)
 
 
 def test_replaceTexture_replacesTexture():
@@ -265,16 +299,14 @@ def test_replaceTexture_unknown_raises():
             aei.replaceTexture(png, Texture(0, 0, 1, 1))
 
 
-def test_replaceTexture_outOfBounds_raises():
+def test_replaceTexture_outOfBounds_warns():
     with Image.new("RGBA", (1, 1)) as png, AEI((10, 10)) as aei:
-        with pytest.raises(ValueError):
-            aei.replaceTexture(png, Texture(11, 0, 1, 1))
+        aei.replaceTexture(png, Texture(11, 0, 1, 1))
 
 
-def test_replaceTexture_withImage_incorrectTexture_raises():
+def test_replaceTexture_withImage_incorrectTexture_warns():
     with Image.new("RGBA", (1, 1)) as png, AEI((10, 10)) as aei:
-        with pytest.raises(ValueError):
-            aei.replaceTexture(png, Texture(10, 0, 2, 2))
+        aei.replaceTexture(png, Texture(10, 0, 2, 2))
 
 
 def test_replaceTexture_withImage_incorrectMode_raises():
@@ -291,9 +323,8 @@ def test_getTexture_getsTexture():
         assert actual.getpixel((0, 0)) == (255, 255, 255, 255) # type: ignore[reportUnknownMemberType]
 
 
-def test_getTexture_outOfBounds_raises():
+def test_getTexture_outOfBounds_warns():
     with AEI((10, 10)) as aei:
-        with pytest.raises(ValueError):
-            aei.getTexture(Texture(11, 0, 10, 10))
+        aei.getTexture(Texture(11, 0, 10, 10))
 
 #endregion textures

--- a/src/tests/image/test_AEI.py
+++ b/src/tests/image/test_AEI.py
@@ -187,7 +187,7 @@ def test_write_twoTextures_isCorrect():
 def test_write_symbols_isCorrect():
     global g_useSmiley
     g_useSmiley = True
-
+    
     _test_tex = [
         # font 0
         Texture(0,0,3,3),
@@ -209,16 +209,17 @@ def test_write_symbols_isCorrect():
                 "ą": _test_tex[3],
                 "™": _test_tex[4]
             })
-            aei.write(temp, format=CompressionFormat.Uncompressed_UI, quality=3)
+            aei.write(temp, format=CompressionFormat.Uncompressed_UI)
+            temp.seek(0)
             with AEI.read(temp) as new_aei:
                 assert len(new_aei.fonts) == 2
                 assert len(new_aei.fonts[0]) == 2
                 assert len(new_aei.fonts[1]) == 3
-                assert new_aei.fonts[0]["."] == _test_tex[0]
-                assert new_aei.fonts[0]["a"] == _test_tex[1]
-                assert new_aei.fonts[1]["ж"] == _test_tex[2]
-                assert new_aei.fonts[1]["ą"] == _test_tex[3]
-                assert new_aei.fonts[1]["™"] == _test_tex[4]
+                assert new_aei.fonts[0]["."].equals(_test_tex[0])
+                assert new_aei.fonts[0]["a"].equals(_test_tex[1])
+                assert new_aei.fonts[1]["ж"].equals(_test_tex[2])
+                assert new_aei.fonts[1]["ą"].equals(_test_tex[3])
+                assert new_aei.fonts[1]["™"].equals(_test_tex[4])
            
     g_useSmiley = False
 
@@ -249,9 +250,15 @@ def test_addTexture_conflict_warns():
         aei.addTexture(Texture(0, 0, 10, 10))
 
 
+def test_addTexture_outOfBounds_raises():
+    with AEI((10, 10)) as aei:
+        with pytest.raises(ValueError):
+            aei.addTexture(Texture(11, 0, 10, 10))
+
+
 def test_addTexture_outOfBounds_warns():
     with AEI((10, 10)) as aei:
-        aei.addTexture(Texture(11, 0, 10, 10))
+        aei.addTexture(Texture(5, 0, 10, 10))
 
 
 def test_addTexture_withImage_incorrectMode_raises():
@@ -281,9 +288,10 @@ def test_removeTexture_unknown_raises():
             aei.removeTexture(0, 0, 10, 10)
 
 
-def test_removeTexture_outOfBounds_warns():
+def test_removeTexture_outOfBounds_raises():
     with AEI((10, 10)) as aei:
-        aei.removeTexture(11, 0, 10, 10)
+        with pytest.raises(ValueError):
+            aei.removeTexture(11, 0, 10, 10)
 
 
 def test_replaceTexture_replacesTexture():
@@ -299,14 +307,22 @@ def test_replaceTexture_unknown_raises():
             aei.replaceTexture(png, Texture(0, 0, 1, 1))
 
 
+def test_replaceTexture_outOfBounds_raises():
+    with Image.new("RGBA", (1, 1)) as png, AEI((10, 10)) as aei:
+        with pytest.raises(ValueError):
+            aei.addTexture(Texture(11, 0, 1, 1))
+            aei.replaceTexture(png, Texture(11, 0, 1, 1))
+
 def test_replaceTexture_outOfBounds_warns():
     with Image.new("RGBA", (1, 1)) as png, AEI((10, 10)) as aei:
-        aei.replaceTexture(png, Texture(11, 0, 1, 1))
+        aei.addTexture(Texture(5, 0, 1, 1))
+        aei.replaceTexture(png, Texture(5, 0, 1, 1))
 
 
-def test_replaceTexture_withImage_incorrectTexture_warns():
+def test_replaceTexture_withImage_incorrectTexture_raises():
     with Image.new("RGBA", (1, 1)) as png, AEI((10, 10)) as aei:
-        aei.replaceTexture(png, Texture(10, 0, 2, 2))
+        with pytest.raises(ValueError):
+            aei.replaceTexture(png, Texture(10, 0, 2, 2))
 
 
 def test_replaceTexture_withImage_incorrectMode_raises():
@@ -323,8 +339,14 @@ def test_getTexture_getsTexture():
         assert actual.getpixel((0, 0)) == (255, 255, 255, 255) # type: ignore[reportUnknownMemberType]
 
 
+def test_getTexture_outOfBounds_raises():
+    with AEI((10, 10)) as aei:
+        with pytest.raises(ValueError):
+            aei.getTexture(Texture(11, 0, 10, 10))
+
+
 def test_getTexture_outOfBounds_warns():
     with AEI((10, 10)) as aei:
-        aei.getTexture(Texture(11, 0, 10, 10))
+        aei.getTexture(Texture(5, 0, 10, 10))
 
 #endregion textures


### PR DESCRIPTION
Added symbols maps parsing and writing. (Didn't test writing)

To fix this https://github.com/Trimatix/AEPi/issues/54 and other issue with [images with dublicate textures](https://github.com/user-attachments/files/22992696/junk.aei.zip) not loading I changes two exceptions to warnings.
[junk.aei.zip](https://github.com/user-attachments/files/22992696/junk.aei.zip)

Having looked at AEI.py in context of some .aeis not loading I came to conclusion that identifying textures by bounding boxes is not ideal, becouse bboxes somtimes overlap, stretch outside the image, are dublicate and propably would be easier to fix these bugs if it was removed to make place for identifing by textures index with. I haven't implemented it.

